### PR TITLE
Add postinstall script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "lib/tsc.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "tsc"
+    "build": "tsc",
+    "postinstall": "npm run build"
   },
   "author": "Google ISE Hardening Team",
   "license": "Apache-2.0",


### PR DESCRIPTION
I want to add tsec github repo as a devDependency in other project (VSCode) and need it to compile automatically during the `yarn install` phase in VSC. Adding a `tsc` command as a `postinstall` script to tsec does exactly that. 